### PR TITLE
Fixing how nested values are handled in the index() function

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -301,8 +301,7 @@ function setupIndexFunctions(InstanceModel) {
       if (indexes.hasOwnProperty(v)) {
         const path = indexes[v].path;
         const name = indexes[v].name;
-        const fnName = 'findBy'.concat(inflection.camelize(name));
-
+        const fnName = 'findBy'.concat(inflection.camelize(inflection.underscore(name)));
         const indexFind = generateIndexFinder(InstanceModel, path, name);
         InstanceModel[fnName] = function () {
           return promisifyCall(this, indexFind, ...arguments);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -199,6 +199,7 @@ export default class Schema {
           if (trailingDigitReg.test(p)) {
             name = p[p.length - 2];
           }
+          p = p.replace('.', '_');
           return inflection.singularize(p);
         });
         indexName = indexName.join('_and_');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -190,7 +190,7 @@ export default class Schema {
    *
    */
   index(prop, options = {}) {
-    const indexType = options.indexType ? options.indexType : 'single';
+    const indexType = options.indexType || 'single';
     let indexName = options.indexName;
     let compound = false;
     if (Array.isArray(prop)) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -190,7 +190,7 @@ export default class Schema {
    *
    */
   index(prop, options = {}) {
-    let indexType = options.indexType ? options.indexType : 'single';
+    const indexType = options.indexType ? options.indexType : 'single';
     let indexName = options.indexName;
     let compound = false;
     if (Array.isArray(prop)) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -189,17 +189,12 @@ export default class Schema {
    * var User = lounge.model('User', userSchema);
    *
    */
-  index(prop, options = {}){
-    if (Array.isArray(prop)){
-      _.each(prop, p => {
-        if (!this.descriptor[p]){
-          throw new Error(`Descriptor not found for ${p}`);
-        }
-      });
-
-      let indexType = options.indexType ? options.indexType: 'single';
-      let indexName = options.indexName;
-      if (!indexName){
+  index(prop, options = {}) {
+    let indexType = options.indexType ? options.indexType : 'single';
+    let indexName = options.indexName;
+    let compound = false;
+    if (Array.isArray(prop)) {
+      if (!indexName) {
         indexName = _.map(prop, p => {
           if (trailingDigitReg.test(p)) {
             name = p[p.length - 2];
@@ -208,20 +203,18 @@ export default class Schema {
         });
         indexName = indexName.join('_and_');
       }
-
-      this.indexes[indexName] = {path: prop, name: indexName, indexType: indexType, compound: true};
+      compound = true;
     } else {
-      if (!this.descriptor[prop]){
-        throw new Error('Descriptor not found for this field');
+      if (!indexName) {
+        indexName = prop
+        if (trailingDigitReg.test(indexName)) {
+          indexName = indexName[indexName.length - 2];
+        }
+
+        indexName = inflection.singularize(indexName);
       }
-
-      this.descriptor[prop].index = true;
-      this.descriptor[prop] = _.extend(this.descriptor[prop], options);
-
-      let fullDes = {};
-      fullDes[prop] = this.descriptor[prop];
-      this._getIndexes(fullDes);
     }
+    this.indexes[indexName] = { path: prop, name: indexName, indexType: indexType, compound: compound };
   }
 
   /**

--- a/test/index.query.spec.js
+++ b/test/index.query.spec.js
@@ -98,7 +98,6 @@ describe('Model index query tests', function () {
         expect(err).to.not.be.ok;
         expect(savedDoc).to.be.ok;
 
-
         User.findByEmailAndUsername(user.email, user.username, function (err, rdoc) {
           expect(err).to.not.be.ok;
 
@@ -115,6 +114,148 @@ describe('Model index query tests', function () {
           expect(rdoc.username).to.equal(userData.username);
 
           done();
+        });
+      });
+    });
+
+    it('should query using compound indexes with nested values', function (done) {
+      var userSchema = lounge.schema({
+        firstName: String,
+        lastName: String,
+        email: String,
+        company: {
+          name: String
+        }
+      });
+
+      userSchema.index(['email', 'company.name']);
+
+      var User = lounge.model('User', userSchema);
+
+      var userData = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'joe@gmail.com',
+        company: {
+          name: 'Acme Inc'
+        }
+      };
+
+      var user = new User(userData);
+
+      user.save(function (err, savedDoc) {
+        expect(err).to.not.be.ok;
+        expect(savedDoc).to.be.ok;
+
+        User.findByEmailAndCompanyName(user.email, user.company.name, function (err, rdoc) {
+          expect(err).to.not.be.ok;
+
+          expect(rdoc).to.be.ok;
+          expect(rdoc).to.be.an('object');
+          expect(rdoc).to.be.an.instanceof(User);
+          expect(rdoc.id).to.be.ok;
+          expect(rdoc.id).to.be.a('string');
+
+          expect(rdoc.id).to.equal(user.id);
+          expect(rdoc.firstName).to.equal(userData.firstName);
+          expect(rdoc.lastName).to.equal(userData.lastName);
+          expect(rdoc.email).to.equal(userData.email);
+          expect(rdoc.company).to.be.ok;
+          expect(rdoc.company).to.be.an('object');
+          expect(rdoc.company.name).to.equal(userData.company.name);
+
+          done();
+        });
+      });
+    });
+
+    it('should query using compound indexes of type array with nested values', function (done) {
+      var userSchema = lounge.schema({
+        firstName: String,
+        lastName: String,
+        email: String,
+        company: {
+          name: String
+        }
+      });
+
+      userSchema.index(['email', 'company.name'], { indexType: 'array' });
+
+      var User = lounge.model('User', userSchema);
+
+      var userData = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'joe@gmail.com',
+        company: {
+          name: 'Acme Inc'
+        }
+      };
+
+      var user = new User(userData);
+
+      user.save(function (err, savedDoc) {
+        expect(err).to.not.be.ok;
+        expect(savedDoc).to.be.ok;
+
+        User.findByEmailAndCompanyName(user.email, user.company.name, function (err, rdoc) {
+          expect(err).to.not.be.ok;
+
+          expect(rdoc).to.be.ok;
+          expect(rdoc).to.be.an('array');
+          expect(rdoc.length).to.equal(1);
+
+          expect(rdoc[0]).to.be.an('object');
+          expect(rdoc[0]).to.be.an.instanceof(User);
+          expect(rdoc[0].id).to.be.ok;
+          expect(rdoc[0].id).to.be.a('string');
+
+          expect(rdoc[0].id).to.equal(user.id);
+          expect(rdoc[0].firstName).to.equal(userData.firstName);
+          expect(rdoc[0].lastName).to.equal(userData.lastName);
+          expect(rdoc[0].email).to.equal(userData.email);
+          expect(rdoc[0].company).to.be.ok;
+          expect(rdoc[0].company).to.be.an('object');
+          expect(rdoc[0].company.name).to.equal(userData.company.name);
+
+          var userData2 = {
+            firstName: 'Joe2',
+            lastName: 'Smith2',
+            email: 'joe@gmail.com',
+            company: {
+              name: 'Acme Inc'
+            }
+          };
+
+          var user2 = new User(userData2);
+
+          user2.save(function (err, savedDoc) {
+            expect(err).to.not.be.ok;
+            expect(savedDoc).to.be.ok;
+
+            User.findByEmailAndCompanyName(user2.email, user2.company.name, function (err, rdoc) {
+              expect(err).to.not.be.ok;
+
+              expect(rdoc).to.be.ok;
+              expect(rdoc).to.be.an('array');
+              expect(rdoc.length).to.equal(2);
+
+              expect(rdoc[1]).to.be.an('object');
+              expect(rdoc[1]).to.be.an.instanceof(User);
+              expect(rdoc[1].id).to.be.ok;
+              expect(rdoc[1].id).to.be.a('string');
+
+              expect(rdoc[1].id).to.equal(user2.id);
+              expect(rdoc[1].firstName).to.equal(userData2.firstName);
+              expect(rdoc[1].lastName).to.equal(userData2.lastName);
+              expect(rdoc[1].email).to.equal(userData2.email);
+              expect(rdoc[1].company).to.be.ok;
+              expect(rdoc[1].company).to.be.an('object');
+              expect(rdoc[1].company.name).to.equal(userData2.company.name);
+
+              done();
+            });
+          });
         });
       });
     });

--- a/test/indexes.spec.js
+++ b/test/indexes.spec.js
@@ -35,7 +35,7 @@ describe('Model index tests', function () {
       var userSchema = new lounge.Schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true}
+        email: { type: String, index: true }
       });
 
       var User = lounge.model('User', userSchema);
@@ -69,7 +69,7 @@ describe('Model index tests', function () {
       var userSchema = new lounge.Schema({
         firstName: String,
         lastName: String,
-        usernames: [{type: String, index: true}]
+        usernames: [{ type: String, index: true }]
       });
 
       var User = lounge.model('User', userSchema);
@@ -100,7 +100,7 @@ describe('Model index tests', function () {
       var userSchema = new lounge.Schema({
         firstName: String,
         lastName: String,
-        usernames: [{type: String, index: true, indexName: 'UN'}]
+        usernames: [{ type: String, index: true, indexName: 'UN' }]
       });
 
       var User = lounge.model('User', userSchema);
@@ -138,8 +138,8 @@ describe('Model index tests', function () {
       var userSchema = lounge.schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true},
-        foo: {type: Foo}
+        email: { type: String, index: true },
+        foo: { type: Foo }
       });
 
       var User = lounge.model('User', userSchema);
@@ -185,8 +185,8 @@ describe('Model index tests', function () {
       var userSchema = lounge.schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true},
-        foo: {type: Foo, index: true}
+        email: { type: String, index: true },
+        foo: { type: Foo, index: true }
       });
 
       var User = lounge.model('User', userSchema);
@@ -214,8 +214,7 @@ describe('Model index tests', function () {
           value: 'joe@gmail.com',
           name: 'email',
           indexType: 'single'
-        }
-        ,
+        },
         'foo': {
           path: 'foo',
           value: foo.id,
@@ -232,7 +231,7 @@ describe('Model index tests', function () {
       var userSchema = lounge.schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true}
+        email: { type: String, index: true }
       });
 
       var User = lounge.model('User', userSchema);
@@ -264,7 +263,7 @@ describe('Model index tests', function () {
       var userSchema = new lounge.Schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true, indexType: 'array'}
+        email: { type: String, index: true, indexType: 'array' }
       });
 
       var User = lounge.model('User', userSchema);
@@ -298,7 +297,7 @@ describe('Model index tests', function () {
       var userSchema = new lounge.Schema({
         firstName: String,
         lastName: String,
-        usernames: [{type: String, index: true, indexType: 'array'}]
+        usernames: [{ type: String, index: true, indexType: 'array' }]
       });
 
       var User = lounge.model('User', userSchema);
@@ -329,7 +328,7 @@ describe('Model index tests', function () {
       var userSchema = new lounge.Schema({
         firstName: String,
         lastName: String,
-        usernames: [{type: String, index: true, indexName: 'UN', indexType: 'array'}]
+        usernames: [{ type: String, index: true, indexName: 'UN', indexType: 'array' }]
       });
 
       var User = lounge.model('User', userSchema);
@@ -356,6 +355,166 @@ describe('Model index tests', function () {
       expect(actualRefs).to.deep.equal(expected);
     });
 
+    it('should create index values for nested values', function () {
+      var userSchema = new lounge.Schema({
+        firstName: String,
+        lastName: String,
+        email: String,
+        company: {
+          name: {
+            type: String,
+            index: true,
+            indexName: 'company',
+            indexType: 'array'
+          }
+        }
+      });
+
+      var User = lounge.model('User', userSchema);
+
+      expect(User.findByCompany).to.be.ok;
+      expect(User.findByCompany).to.be.an.instanceof(Function);
+
+      var data = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'jsmith@acme.inc',
+        company: { name: 'Acme Inc' }
+      };
+
+      var expected = {
+        'company': {
+          path: 'company.name',
+          value: 'Acme Inc',
+          name: 'company',
+          indexType: 'array'
+        }
+      };
+
+      var actualRefs = couchUtil.buildRefValues(userSchema.indexes, data);
+      expect(actualRefs).to.deep.equal(expected);
+    });
+
+    it('should create index values for nested values through index function', function () {
+      var userSchema = new lounge.Schema({
+        firstName: String,
+        lastName: String,
+        email: String,
+        company: {
+          name: {
+            type: String
+          }
+        }
+      });
+
+      userSchema.index('company.name', {indexName: 'company', indexType: 'array'});
+
+      var User = lounge.model('User', userSchema);
+
+      expect(User.findByCompany).to.be.ok;
+      expect(User.findByCompany).to.be.an.instanceof(Function);
+
+      var data = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'jsmith@acme.inc',
+        company: { name: 'Acme Inc' }
+
+      };
+
+      var expected = {
+        'company': {
+          path: 'company.name',
+          value: 'Acme Inc',
+          name: 'company',
+          indexType: 'array'
+        }
+      };
+
+      var actualRefs = couchUtil.buildRefValues(userSchema.indexes, data);
+      expect(actualRefs).to.deep.equal(expected);
+    });
+
+    it('should create compound index values for nested values', function () {
+      var userSchema = new lounge.Schema({
+        firstName: String,
+        lastName: String,
+        email: String,
+        company: {
+          name: String
+        }
+      });
+
+      userSchema.index(['email', 'company.name'], { indexName: 'company', indexType: 'array' });
+
+      var User = lounge.model('User', userSchema);
+
+      expect(User.findByCompany).to.be.ok;
+      expect(User.findByCompany).to.be.an.instanceof(Function);
+
+      var data = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'jsmith@acme.inc',
+        company: { name: 'Acme Inc' }
+
+      };
+
+      var expected = {
+        'company': {
+          path: ['email', 'company.name'],
+          value: 'jsmith@acme.inc_Acme Inc',
+          name: 'company',
+          indexType: 'array'
+        }
+      };
+
+      var actualRefs = couchUtil.buildRefValues(userSchema.indexes, data);
+      expect(actualRefs).to.deep.equal(expected);
+    });
+
+    it.skip('should create index values for nested values within an array', function () {
+      var userSchema = new lounge.Schema({
+        firstName: String,
+        lastName: String,
+        email: String,
+        companies: [{
+          name: {
+            type: String,
+            index: true,
+            indexName: 'company',
+            indexType: 'array'
+          }
+        }]
+      });
+
+      var User = lounge.model('User', userSchema);
+
+      expect(User.findByCompany).to.be.ok;
+      expect(User.findByCompany).to.be.an.instanceof(Function);
+
+      var data = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        companies: [
+          { name: 'Acme Inc' },
+          { name: 'Test Co' }
+        ]
+      };
+
+      var expected = {
+        'company': {
+          path: 'company.name',
+          value: ['Acme Inc', 'Test Co'],
+          name: 'company',
+          indexType: 'array'
+        }
+      };
+
+      var actualRefs = couchUtil.buildRefValues(userSchema.indexes, data);
+      expect(actualRefs).to.deep.equal(expected);
+    });
+
     it('should not create index value for a ref field if not specified', function () {
       var fooSchema = lounge.schema({
         a: String,
@@ -367,8 +526,8 @@ describe('Model index tests', function () {
       var userSchema = lounge.schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true, indexType: 'array'},
-        foo: {type: Foo}
+        email: { type: String, index: true, indexType: 'array' },
+        foo: { type: Foo }
       });
 
       var User = lounge.model('User', userSchema);
@@ -414,8 +573,8 @@ describe('Model index tests', function () {
       var userSchema = lounge.schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true},
-        foo: {type: Foo, index: true, indexType: 'array'}
+        email: { type: String, index: true },
+        foo: { type: Foo, index: true, indexType: 'array' }
       });
 
       var User = lounge.model('User', userSchema);
@@ -443,8 +602,7 @@ describe('Model index tests', function () {
           value: 'joe@gmail.com',
           name: 'email',
           indexType: 'single'
-        }
-        ,
+        },
         'foo': {
           path: 'foo',
           value: foo.id,
@@ -461,7 +619,7 @@ describe('Model index tests', function () {
       var userSchema = lounge.schema({
         firstName: String,
         lastName: String,
-        email: {type: String, index: true, indexType: 'array'}
+        email: { type: String, index: true, indexType: 'array' }
       });
 
       var User = lounge.model('User', userSchema);

--- a/test/model.index.spec.js
+++ b/test/model.index.spec.js
@@ -172,6 +172,7 @@ describe('Model index function tests', function () {
     });
 
     function checkIndexRes(err, indexRes) {
+      console.dir(err);
       expect(err).to.not.be.ok;
       expect(indexRes).to.be.ok;
       expect(indexRes.value).to.be.ok;
@@ -194,6 +195,9 @@ describe('Model index function tests', function () {
 
       var k = userSchema.getRefKey('email_and_username', user.email + '_' + user.username);
       bucket.get(k, function (err, indexRes) {
+        console.log('Err');
+        console.dir(err);
+        console.log('****');
         checkIndexRes(err, indexRes);
 
         bucket.get(indexRes.value.key, function (err, gd) {

--- a/test/model.index.spec.js
+++ b/test/model.index.spec.js
@@ -172,7 +172,6 @@ describe('Model index function tests', function () {
     });
 
     function checkIndexRes(err, indexRes) {
-      console.dir(err);
       expect(err).to.not.be.ok;
       expect(indexRes).to.be.ok;
       expect(indexRes.value).to.be.ok;
@@ -195,11 +194,7 @@ describe('Model index function tests', function () {
 
       var k = userSchema.getRefKey('email_and_username', user.email + '_' + user.username);
       bucket.get(k, function (err, indexRes) {
-        console.log('Err');
-        console.dir(err);
-        console.log('****');
         checkIndexRes(err, indexRes);
-
         bucket.get(indexRes.value.key, function (err, gd) {
           checkGetRes(err, gd);
           done();


### PR DESCRIPTION
We needed to remove the check in the index function as nested values were not being validated properly. Should create a task to populate the descriptor properly for nested values (not sure how to do this yet). In any case this will still work just as it does through the in schema index definition. 

Also added a test for indexing nested values in an array. This will be added in a future PR. 
